### PR TITLE
Data validation

### DIFF
--- a/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
@@ -2,6 +2,7 @@ package net.sf.jabref.bibtex;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Calendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -139,6 +140,25 @@ public class BibEntryWriter {
         // the first condition mirrors mirror behavior of com.jgoodies.common.base.Strings.isNotBlank(str)
         if (!Strings.nullToEmpty(field).trim().isEmpty()) {
             out.write("  " + getFieldDisplayName(name, indentation));
+
+            if (name.equals("year")) {
+                int curr = Calendar.getInstance().get(Calendar.YEAR);
+                int y;
+
+                try {
+                    y = Integer.parseInt(field);
+                } catch (NumberFormatException ex) {
+                    throw new NumberFormatException("Error in field '" + name + "': " + ex.getMessage());
+                } catch (NullPointerException ex) {
+                    throw new NullPointerException("Error in field '" + name + "': " + ex.getMessage());
+                }
+
+                if ((y < 0) || (y > curr)) {
+                    field = Integer.toString(curr);
+                } else {
+                    field = Integer.toString(y);
+                }
+            }
 
             try {
                 out.write(fieldFormatter.format(field, name));

--- a/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
@@ -123,6 +123,7 @@ public class BibEntryWriter {
 
     private void writeKeyField(BibEntry entry, Writer out) throws IOException {
         String keyField = StringUtil.shaveString(entry.getCiteKey());
+        keyField = BibEntry.validateId(keyField);
         out.write(keyField + ',' + Globals.NEWLINE);
     }
 

--- a/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
@@ -10,6 +10,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
 
+import javax.swing.JOptionPane;
+
 import net.sf.jabref.Globals;
 import net.sf.jabref.exporter.LatexFieldFormatter;
 import net.sf.jabref.logic.TypedBibEntry;
@@ -139,27 +141,22 @@ public class BibEntryWriter {
         String field = entry.getField(name);
         // only write field if is is not empty or if empty fields should be included
         // the first condition mirrors mirror behavior of com.jgoodies.common.base.Strings.isNotBlank(str)
+        if (name.equals("year") && !Strings.nullToEmpty(field).trim().isEmpty()) {
+            int curr = Calendar.getInstance().get(Calendar.YEAR);
+            int y = -1;
+            try {
+                y = Integer.parseInt(field);
+            } catch (NumberFormatException | NullPointerException ex) {
+                JOptionPane.showMessageDialog(null, "Error in field '" + name + "': " + ex.getMessage());
+            }
+
+            if (y < 0) {
+                field = null;
+            }
+        }
+
         if (!Strings.nullToEmpty(field).trim().isEmpty()) {
             out.write("  " + getFieldDisplayName(name, indentation));
-
-            if (name.equals("year")) {
-                int curr = Calendar.getInstance().get(Calendar.YEAR);
-                int y;
-
-                try {
-                    y = Integer.parseInt(field);
-                } catch (NumberFormatException ex) {
-                    throw new NumberFormatException("Error in field '" + name + "': " + ex.getMessage());
-                } catch (NullPointerException ex) {
-                    throw new NullPointerException("Error in field '" + name + "': " + ex.getMessage());
-                }
-
-                if ((y < 0) || (y > curr)) {
-                    field = Integer.toString(curr);
-                } else {
-                    field = Integer.toString(y);
-                }
-            }
 
             try {
                 out.write(fieldFormatter.format(field, name));

--- a/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
@@ -15,6 +15,7 @@ import javax.swing.JOptionPane;
 import net.sf.jabref.Globals;
 import net.sf.jabref.exporter.LatexFieldFormatter;
 import net.sf.jabref.logic.TypedBibEntry;
+import net.sf.jabref.logic.labelpattern.LabelPatternUtil;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -125,7 +126,12 @@ public class BibEntryWriter {
 
     private void writeKeyField(BibEntry entry, Writer out) throws IOException {
         String keyField = StringUtil.shaveString(entry.getCiteKey());
-        keyField = BibEntry.validateId(keyField);
+
+        if ((keyField.length() == 0) || (keyField.length() == 1) || !Character.isLetter(keyField.charAt(0))) {
+            keyField = LabelPatternUtil.checkLegalKey(keyField, true);
+        }
+
+        entry.setCiteKey(keyField);
         out.write(keyField + ',' + Globals.NEWLINE);
     }
 
@@ -152,6 +158,8 @@ public class BibEntryWriter {
 
             if (y < 0) {
                 field = null;
+            } else {
+                entry.setChanged(true);
             }
         }
 

--- a/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
@@ -1421,6 +1421,9 @@ public class LabelPatternUtil {
         StringBuilder newKey = new StringBuilder();
         for (int i = 0; i < key.length(); i++) {
             char c = key.charAt(i);
+            if (((i == 0) && Character.isDigit(c))) {
+                break;
+            }
             if ((key.length() > 1) && !Character.isWhitespace(c) && ("{}(),\\\"#~^'".indexOf(c) == -1) && !((i == 0) && Character.isDigit(c))) {
                 newKey.append(c);
             }

--- a/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
@@ -1401,9 +1401,9 @@ public class LabelPatternUtil {
      * @param enforceLegalKey make sure that the key is legal in all respects
      */
     public static String checkLegalKey(String key, boolean enforceLegalKey) {
-        if (key == null) {
+        /*if (key == null) {
             return null;
-        }
+        }*/
         if (!enforceLegalKey) {
             // User doesn't want us to enforce legal characters. We must still look
             // for whitespace and some characters such as commas, since these would
@@ -1421,7 +1421,7 @@ public class LabelPatternUtil {
         StringBuilder newKey = new StringBuilder();
         for (int i = 0; i < key.length(); i++) {
             char c = key.charAt(i);
-            if (!Character.isWhitespace(c) && ("{}(),\\\"#~^'".indexOf(c) == -1)) {
+            if ((key.length() > 1) && !Character.isWhitespace(c) && ("{}(),\\\"#~^'".indexOf(c) == -1) && !((i == 0) && Character.isDigit(c))) {
                 newKey.append(c);
             }
         }

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -29,7 +29,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -96,8 +95,6 @@ public class BibEntry implements Cloneable {
     public BibEntry(String id, String type) {
         Objects.requireNonNull(id, "Every BibEntry must have an ID");
 
-        id = validateId(id);
-
         this.id = id;
         setType(type);
     }
@@ -111,7 +108,6 @@ public class BibEntry implements Cloneable {
     public void setId(String id) {
         Objects.requireNonNull(id, "Every BibEntry must have an ID");
 
-        id = validateId(id);
         eventBus.post(new FieldChangedEvent(this, BibEntry.ID_FIELD, id));
         this.id = id;
         changed = true;
@@ -621,17 +617,5 @@ public class BibEntry implements Cloneable {
      * @param ID The BibTeX ID to be validated
      * @return
      */
-
-    public static String validateId(String ID) {
-        Random r = new Random();
-        char c = (char) (r.nextInt(26) + 'a');
-        if ((ID.length() == 0) || !Character.isLetter(ID.charAt(0))) {
-            ID = c + ID;
-        }
-        if (ID.length() == 1) {
-            ID = ID + r.nextInt(10);
-        }
-        return ID;
-    }
 
 }

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -95,6 +96,8 @@ public class BibEntry implements Cloneable {
     public BibEntry(String id, String type) {
         Objects.requireNonNull(id, "Every BibEntry must have an ID");
 
+        id = validateId(id);
+
         this.id = id;
         setType(type);
     }
@@ -108,9 +111,28 @@ public class BibEntry implements Cloneable {
     public void setId(String id) {
         Objects.requireNonNull(id, "Every BibEntry must have an ID");
 
+        id = validateId(id);
         eventBus.post(new FieldChangedEvent(this, BibEntry.ID_FIELD, id));
         this.id = id;
         changed = true;
+    }
+
+    /**
+     * Checks and corrects a given ID, that is, ensures it
+     * always starts with a letter.
+     * @param ID The BibTeX ID to be validated
+     * @return
+     */
+
+    private String validateId(String ID) {
+        Random r = new Random();
+        char c = (char) (r.nextInt(26) + 'a');
+        if (ID.length() == 0) {
+            ID = ID + c;
+        } else if (!Character.isLetter(ID.charAt(0))) {
+            ID = c + ID;
+        }
+        return ID;
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -118,24 +118,6 @@ public class BibEntry implements Cloneable {
     }
 
     /**
-     * Checks and corrects a given ID, that is, ensures it
-     * always starts with a letter.
-     * @param ID The BibTeX ID to be validated
-     * @return
-     */
-
-    private String validateId(String ID) {
-        Random r = new Random();
-        char c = (char) (r.nextInt(26) + 'a');
-        if (ID.length() == 0) {
-            ID = ID + c;
-        } else if (!Character.isLetter(ID.charAt(0))) {
-            ID = c + ID;
-        }
-        return ID;
-    }
-
-    /**
      * Returns this entry's ID.
      */
     public String getId() {
@@ -631,6 +613,24 @@ public class BibEntry implements Cloneable {
 
     public void unregisterListener(Object object) {
         this.eventBus.unregister(object);
+    }
+
+    /**
+     * Checks and corrects a given ID, that is, ensures it
+     * always starts with a letter.
+     * @param ID The BibTeX ID to be validated
+     * @return
+     */
+
+    public static String validateId(String ID) {
+        Random r = new Random();
+        char c = (char) (r.nextInt(26) + 'a');
+        if (ID.length() == 0) {
+            ID = ID + c;
+        } else if (!Character.isLetter(ID.charAt(0))) {
+            ID = c + ID;
+        }
+        return ID;
     }
 
 }

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -625,10 +625,11 @@ public class BibEntry implements Cloneable {
     public static String validateId(String ID) {
         Random r = new Random();
         char c = (char) (r.nextInt(26) + 'a');
-        if (ID.length() == 0) {
-            ID = ID + c;
-        } else if (!Character.isLetter(ID.charAt(0))) {
+        if ((ID.length() == 0) || !Character.isLetter(ID.charAt(0))) {
             ID = c + ID;
+        }
+        if (ID.length() == 1) {
+            ID = ID + r.nextInt(10);
         }
         return ID;
     }

--- a/src/test/java/net/sf/jabref/es2test/DataValidationTest.java
+++ b/src/test/java/net/sf/jabref/es2test/DataValidationTest.java
@@ -1,0 +1,202 @@
+package net.sf.jabref.es2test;
+
+import net.sf.jabref.model.database.BibDatabaseMode;
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.BibtexEntryTypes;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.bibtex.BibEntryWriter;
+import net.sf.jabref.exporter.LatexFieldFormatter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DataValidationTest {
+
+    private BibEntry newEntryA;
+
+    private BibEntryWriter writer;
+
+
+    @Before
+    public void setUp() {
+        Globals.prefs = JabRefPreferences.getInstance();
+        newEntryA = new BibEntry();
+        newEntryA.setType(BibtexEntryTypes.ARTICLE);
+        writer = new BibEntryWriter(new LatexFieldFormatter(), true);
+    }
+
+    @Test
+    public void bibtexTestArticleYearEquals() {
+        StringWriter stringWriter = new StringWriter();
+
+        newEntryA.setField("year", "2003");
+
+        try {
+            writer.write(newEntryA, stringWriter, BibDatabaseMode.BIBTEX);
+        } catch (IOException e) {
+        }
+
+        String actual = stringWriter.toString();
+
+        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE + "  year = {2003}," + Globals.NEWLINE + "}"
+                + Globals.NEWLINE;
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void bibtexTestArticleYearNotEquals() {
+        StringWriter stringWriter = new StringWriter();
+
+        newEntryA.setField("year", "2003");
+
+        try {
+            writer.write(newEntryA, stringWriter, BibDatabaseMode.BIBTEX);
+        } catch (IOException e) {
+        }
+
+        String actual = stringWriter.toString();
+
+        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE + "  year = {2008}," + Globals.NEWLINE + "}"
+                + Globals.NEWLINE;
+
+        Assert.assertNotEquals(actual, expected);
+    }
+
+    @Test
+    public void bibtexTestArticleYearLetter() {
+        StringWriter stringWriter = new StringWriter();
+
+        newEntryA.setField("year", "hello");
+
+        try {
+            writer.write(newEntryA, stringWriter, BibDatabaseMode.BIBTEX);
+        } catch (IOException e) {
+        }
+
+        String actual = stringWriter.toString();
+
+        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE + "}" + Globals.NEWLINE;
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void bibtexTestArticleYearNegative() {
+        StringWriter stringWriter = new StringWriter();
+
+        newEntryA.setField("year", "-1");
+
+        try {
+            writer.write(newEntryA, stringWriter, BibDatabaseMode.BIBTEX);
+        } catch (IOException e) {
+        }
+
+        String actual = stringWriter.toString();
+
+        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE + "}" + Globals.NEWLINE;
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void bibtexTestArticleYearEmpty() {
+        StringWriter stringWriter = new StringWriter();
+
+        newEntryA.setField("year", "");
+
+        try {
+            writer.write(newEntryA, stringWriter, BibDatabaseMode.BIBTEX);
+        } catch (IOException e) {
+        }
+
+        String actual = stringWriter.toString();
+
+        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE + "}" + Globals.NEWLINE;
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void bibtexTestArticleKeyCorrect() {
+        StringWriter stringWriter = new StringWriter();
+
+        newEntryA.setCiteKey("key");
+
+        try {
+            writer.write(newEntryA, stringWriter, BibDatabaseMode.BIBTEX);
+        } catch (IOException e) {
+        }
+
+        String actual = stringWriter.toString();
+
+        String expected = Globals.NEWLINE + "@Article{key," + Globals.NEWLINE + "}" + Globals.NEWLINE;
+
+        Assert.assertEquals(actual, expected);
+
+    }
+
+    @Test
+    public void bibtexTestArticleKeyTooSmall() {
+        StringWriter stringWriter = new StringWriter();
+
+        newEntryA.setCiteKey("k");
+
+        try {
+            writer.write(newEntryA, stringWriter, BibDatabaseMode.BIBTEX);
+        } catch (IOException e) {
+        }
+
+        String actual = stringWriter.toString();
+
+        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE + "}" + Globals.NEWLINE;
+
+        Assert.assertEquals(actual, expected);
+
+    }
+
+    @Test
+    public void bibtexTestArticleKeyEmpty() {
+        StringWriter stringWriter = new StringWriter();
+
+        newEntryA.setCiteKey("");
+
+        try {
+            writer.write(newEntryA, stringWriter, BibDatabaseMode.BIBTEX);
+        } catch (IOException e) {
+        }
+
+        String actual = stringWriter.toString();
+
+        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE + "}" + Globals.NEWLINE;
+
+        Assert.assertEquals(actual, expected);
+
+    }
+
+    @Test
+    public void bibtexTestArticleKeyNumber() {
+        StringWriter stringWriter = new StringWriter();
+
+        newEntryA.setCiteKey("123");
+
+        try {
+            writer.write(newEntryA, stringWriter, BibDatabaseMode.BIBTEX);
+        } catch (IOException e) {
+        }
+
+        String actual = stringWriter.toString();
+
+        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE + "}" + Globals.NEWLINE;
+
+        Assert.assertEquals(actual, expected);
+
+    }
+
+
+}

--- a/src/test/java/net/sf/jabref/es2test/NewEntryTest.java
+++ b/src/test/java/net/sf/jabref/es2test/NewEntryTest.java
@@ -116,6 +116,23 @@ public class NewEntryTest {
     }
 
     @Test
+    public void bibtexTestArticleDuplicateKeys() {
+        BibEntry newEntryA2 = new BibEntry();
+        newEntryA2.setType(BibtexEntryTypes.ARTICLE);
+        String srcString = new String();
+        String srcString2 = new String();
+        newEntryA.setField("bibtexkey", "key");
+        newEntryA2.setField("bibtexkey", "key");
+        try {
+            srcString = EntryEditor.getSourceString(newEntryA, BibDatabaseMode.BIBTEX);
+            srcString2 = EntryEditor.getSourceString(newEntryA2, BibDatabaseMode.BIBTEX);
+        } catch (IOException e) {
+        }
+        Assert.assertEquals("@Article{key,\n}", srcString);
+        Assert.assertEquals("@Article{key,\n}", srcString2);
+    }
+
+    @Test
     public void bibtexTestBook() {
         String srcString = new String();
         try {
@@ -199,6 +216,23 @@ public class NewEntryTest {
         Assert.assertEquals(
                 "@Book{MNO,\n  title     = {ABC},\n  publisher = {DEF},\n  author    = {GHI},\n  editor    = {JKL},\n}",
                 srcString);
+    }
+
+    @Test
+    public void bibtexTestBookDuplicateKeys() {
+        BibEntry newEntryB2 = new BibEntry();
+        newEntryB2.setType(BibtexEntryTypes.BOOK);
+        String srcString = new String();
+        String srcString2 = new String();
+        newEntryB.setField("bibtexkey", "key");
+        newEntryB2.setField("bibtexkey", "key");
+        try {
+            srcString = EntryEditor.getSourceString(newEntryB, BibDatabaseMode.BIBTEX);
+            srcString2 = EntryEditor.getSourceString(newEntryB2, BibDatabaseMode.BIBTEX);
+        } catch (IOException e) {
+        }
+        Assert.assertEquals("@Book{key,\n}", srcString);
+        Assert.assertEquals("@Book{key,\n}", srcString2);
     }
 
 }


### PR DESCRIPTION
Implementada a validação do campo "year" e da "bibtexkey", resolve #2 .

O campo "year" considera como ano válido qualquer valor inteiro positivo. 
A chave (bibtexkey) é considerada válida se contiver ao menos 2 caracteres, sendo o primeiro uma letra (maiúscula ou minúscula).

Foram adicionados, também, testes para estas validações. Então, resolve #9 .
