### PR TITLE
Import duplicate

### DIFF
--- a/bin/tmp/tempNewDatabase
+++ b/bin/tmp/tempNewDatabase
@@ -1,0 +1,17 @@
+@article{small,
+  author = {Freely, I.P.},
+  journal = {The journal of small papers},
+  note = {to appear},
+  title = {A small paper},
+  volume = {-1},
+  year = {1997}
+}
+
+@article{big,
+  author = {Jass, Hugh},
+  journal = {The journal of big papers},
+  title = {A big paper},
+  volume = {MCMXCVII},
+  year = {7991}
+}
+

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -26,6 +26,7 @@ import java.awt.event.MouseListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -619,6 +620,19 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             // see if there
             // are unresolved duplicates, and warn if yes.
             if (Globals.prefs.getBoolean(JabRefPreferences.WARN_ABOUT_DUPLICATES_IN_INSPECTION)) {
+
+                //File newFile = new File("bin/tmp/tempNewDatabase");
+                PrintWriter newFile = null;
+                /*try {
+                    newFile = new PrintWriter("bin/tmp/tempNewDatabase", "UTF-8");
+                    for (BibEntry entry : entries) {
+                        newFile.println(entry);
+                        newFile.print("\n");
+                    }
+                    newFile.close();
+                } catch (FileNotFoundException | UnsupportedEncodingException e) {
+                }*/
+
                 for (BibEntry entry : entries) {
 
                     // Only check entries that are to be imported. Keep status
@@ -644,12 +658,11 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                         if (answer == JOptionPane.NO_OPTION) {
                             //chamar novo database
                             ImportMenuItem imi = new ImportMenuItem(frame, true, null);
-                            imi.automatedImport(Collections.singletonList(
-                                    "/home/matheus/eclipse/workspace/jabref/src/test/resources/net/sf/jabref/es2test/es2bib.bib"));
+                            imi.automatedImport(Collections.singletonList("bin/tmp/tempNewDatabase"));
+
                             dispose();
                             return;
                         }
-
                         break;
                     }
                 }

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -25,8 +25,10 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -623,7 +625,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
 
                 //File newFile = new File("bin/tmp/tempNewDatabase");
                 PrintWriter newFile = null;
-                /*try {
+                try {
                     newFile = new PrintWriter("bin/tmp/tempNewDatabase", "UTF-8");
                     for (BibEntry entry : entries) {
                         newFile.println(entry);
@@ -631,7 +633,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                     }
                     newFile.close();
                 } catch (FileNotFoundException | UnsupportedEncodingException e) {
-                }*/
+                }
 
                 for (BibEntry entry : entries) {
 
@@ -659,6 +661,9 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                             //chamar novo database
                             ImportMenuItem imi = new ImportMenuItem(frame, true, null);
                             imi.automatedImport(Collections.singletonList("bin/tmp/tempNewDatabase"));
+                            BasePanel newPanel = (BasePanel) frame.getTabbedPane().getSelectedComponent();
+                            newPanel.getBibDatabaseContext().setDatabaseFile(null);
+                            newPanel.markBaseChanged();
 
                             dispose();
                             return;

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -89,6 +89,7 @@ import net.sf.jabref.gui.undo.UndoableRemoveEntry;
 import net.sf.jabref.gui.util.comparator.IconComparator;
 import net.sf.jabref.gui.util.component.CheckBoxMessage;
 import net.sf.jabref.importer.ImportInspector;
+import net.sf.jabref.importer.ImportMenuItem;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.logic.groups.AllEntriesGroup;
 import net.sf.jabref.logic.groups.EntriesGroupChange;
@@ -633,7 +634,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                     if (entry.isGroupHit()) {
                         CheckBoxMessage cbm = new CheckBoxMessage(
                                 Localization
-                                        .lang("There are possible duplicates (marked with an icon) that haven't been resolved. Continue?"),
+                                        .lang("There are possible duplicates (marked with an icon) that haven't been resolved. Do you want to proceed (yes) or add them to a new database (no)?"),
                                 Localization.lang("Disable this confirmation dialog"), false);
                         int answer = JOptionPane.showConfirmDialog(ImportInspectionDialog.this, cbm,
                                 Localization.lang("Duplicates found"), JOptionPane.YES_NO_OPTION);
@@ -641,8 +642,14 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                             Globals.prefs.putBoolean(JabRefPreferences.WARN_ABOUT_DUPLICATES_IN_INSPECTION, false);
                         }
                         if (answer == JOptionPane.NO_OPTION) {
+                            //chamar novo database
+                            ImportMenuItem imi = new ImportMenuItem(frame, true, null);
+                            imi.automatedImport(Collections.singletonList(
+                                    "/home/matheus/eclipse/workspace/jabref/src/test/resources/net/sf/jabref/es2test/es2bib.bib"));
+                            dispose();
                             return;
                         }
+
                         break;
                     }
                 }

--- a/src/main/java/net/sf/jabref/importer/ImportFormats.java
+++ b/src/main/java/net/sf/jabref/importer/ImportFormats.java
@@ -107,6 +107,20 @@ public class ImportFormats {
                 if (file == null) {
                     return;
                 }
+                /*System.out.println(file);
+                if (!openInNew) {
+                    File newFile = new File("bin/tmp/tempNewDatabase");
+                    FileChannel source = null;
+                    FileChannel destination = null;
+                    try {
+                        source = new FileInputStream(file).getChannel();
+                        destination = new FileOutputStream(newFile).getChannel();
+                        destination.transferFrom(source, 0, source.size());
+                        source.close();
+                        destination.close();
+                    } catch (IOException exc) {
+                    }
+                }*/
 
                 FileFilter ff = fileChooser.getFileFilter();
                 ImportFormat format = null;

--- a/src/test/java/net/sf/jabref/es2test/ImportDuplicateTest.java
+++ b/src/test/java/net/sf/jabref/es2test/ImportDuplicateTest.java
@@ -1,0 +1,141 @@
+package net.sf.jabref.es2test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.swing.JButton;
+
+import net.sf.jabref.JabRefMain;
+import net.sf.jabref.gui.AWTExceptionHandler;
+import net.sf.jabref.gui.ImportInspectionDialog;
+import net.sf.jabref.gui.JabRefFrame;
+import org.assertj.swing.core.GenericTypeMatcher;
+import org.assertj.swing.dependency.jsr305.Nonnull;
+import org.assertj.swing.fixture.AbstractWindowFixture;
+import org.assertj.swing.fixture.DialogFixture;
+import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.fixture.JFileChooserFixture;
+import org.assertj.swing.image.ScreenshotTaker;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+import org.junit.Test;
+
+import static org.assertj.swing.finder.WindowFinder.findDialog;
+import static org.assertj.swing.finder.WindowFinder.findFrame;
+import static org.assertj.swing.launcher.ApplicationLauncher.application;
+
+public class ImportDuplicateTest extends AssertJSwingJUnitTestCase {
+
+    private AWTExceptionHandler awtExceptionHandler;
+
+    @Override
+    protected void onSetUp() {
+        awtExceptionHandler = new AWTExceptionHandler();
+        awtExceptionHandler.installExceptionDetectionInEDT();
+        application(JabRefMain.class).start();
+
+        robot().waitForIdle();
+
+        robot().settings().timeoutToFindSubMenu(1_000);
+        robot().settings().delayBetweenEvents(50);
+    }
+
+    private void exitJabRef(FrameFixture mainFrame) {
+        mainFrame.menuItemWithPath("File", "Quit").click();
+        awtExceptionHandler.assertNoExceptions();
+    }
+
+    private String getTestFilePath(String fileName) {
+        return new File(this.getClass().getClassLoader().getResource(fileName).getFile()).getAbsolutePath();
+    }
+
+    private void importBibIntoNewDatabase(FrameFixture mainFrame, String path) {
+        // have to replace backslashes with normal slashes b/c assertJ can't type the former one on windows
+        path = path.replace("\\", "/");
+
+        mainFrame.menuItemWithPath("File", "Import into new database").click();
+        JFileChooserFixture openFileDialog = mainFrame.fileChooser();
+        robot().settings().delayBetweenEvents(1);
+        openFileDialog.fileNameTextBox().enterText(path);
+        robot().settings().delayBetweenEvents(1_000);
+        openFileDialog.approve();
+        robot().settings().delayBetweenEvents(50);
+    }
+
+    private void importBibIntoCurrentDatabase(FrameFixture mainFrame, String path) {
+        // have to replace backslashes with normal slashes b/c assertJ can't type the former one on windows
+        path = path.replace("\\", "/");
+
+        mainFrame.menuItemWithPath("File", "Import into current database").click();
+        JFileChooserFixture openFileDialog = mainFrame.fileChooser();
+        robot().settings().delayBetweenEvents(1);
+        openFileDialog.fileNameTextBox().enterText(path);
+        robot().settings().delayBetweenEvents(1_000);
+        openFileDialog.approve();
+        robot().settings().delayBetweenEvents(50);
+    }
+
+    private void saveDatabase(FrameFixture mainFrame, String path) {
+        // have to replace backslashes with normal slashes b/c assertJ can't type the former one on windows
+        path = path.replace("\\", "/");
+
+        mainFrame.menuItemWithPath("File", "Save database").click();
+        JFileChooserFixture openFileDialog = mainFrame.fileChooser();
+        robot().settings().delayBetweenEvents(1);
+        openFileDialog.fileNameTextBox().enterText(path);
+        robot().settings().delayBetweenEvents(1_000);
+        openFileDialog.approve();
+        robot().settings().delayBetweenEvents(50);
+    }
+
+    @Test
+    public void testDuplicateEntries() throws IOException {
+        FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
+        String path = getTestFilePath("net/sf/jabref/es2test/es2bib.bib");
+        importBibIntoNewDatabase(mainFrame, path);
+        importBibIntoCurrentDatabase(mainFrame, path);
+
+        DialogFixture importInspectionDialog = findDialog(ImportInspectionDialog.class).withTimeout(10_000)
+                .using(robot());
+        takeScreenshot(importInspectionDialog, "ImportInspectionDialog1");
+
+        importInspectionDialog.button(new GenericTypeMatcher<JButton>(JButton.class) {
+
+                    @Override
+                    protected boolean isMatching(@Nonnull JButton jButton) {
+                        return "OK".equals(jButton.getText());
+                    }
+                }).click();
+        robot().settings().delayBetweenEvents(100);
+        takeScreenshot(importInspectionDialog, "ImportInspectionDialog2");
+        importInspectionDialog.button(new GenericTypeMatcher<JButton>(JButton.class) {
+
+                    @Override
+                    protected boolean isMatching(@Nonnull JButton jButton) {
+                        return "No".equals(jButton.getText());
+                    }
+                }).click();
+
+        takeScreenshot(mainFrame, "MainFrame");
+
+        exitJabRef(mainFrame);
+    }
+
+    private void takeScreenshot(AbstractWindowFixture<?, ?, ?> dialog, String filename) throws IOException {
+        ScreenshotTaker screenshotTaker = new ScreenshotTaker();
+        String path = getTestFilePath("net/sf/jabref/es2test/es2bib.bib");
+        Path folder = Paths.get(path.substring(0, path.length() - 10));
+        // Create build/srceenshots folder if not present
+        if (!Files.exists(folder)) {
+            Files.createDirectory(folder);
+        }
+        Path file = folder.resolve(filename + ".png").toAbsolutePath();
+        // Delete already present file
+        if (Files.exists(file)) {
+            Files.delete(file);
+        }
+        screenshotTaker.saveComponentAsPng(dialog.target(), file.toString());
+    }
+}

--- a/src/test/java/net/sf/jabref/es2test/ImportItemTest.java
+++ b/src/test/java/net/sf/jabref/es2test/ImportItemTest.java
@@ -18,7 +18,6 @@ public class ImportItemTest {
 
     private BibtexImporter importer;
 
-
     @Before
     public void setUp() {
         Globals.prefs = JabRefPreferences.getInstance();

--- a/src/test/java/net/sf/jabref/es2test/ImportItemTest.java
+++ b/src/test/java/net/sf/jabref/es2test/ImportItemTest.java
@@ -18,6 +18,7 @@ public class ImportItemTest {
 
     private BibtexImporter importer;
 
+
     @Before
     public void setUp() {
         Globals.prefs = JabRefPreferences.getInstance();


### PR DESCRIPTION
Foi implementada, na funcionalidade de importação ao database corrente, a opção de gerar um novo database se houver duplicatas entre o arquivo corrente e o que está sendo importado. Resolve #4 .

Foram implementados testes na GUI para esta manutenção. Resolve #8 .
