### PR TITLE
Parse bib comments

### DIFF
--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -72,7 +72,7 @@ public class BibtexParser {
     private ParserResult parserResult;
     private static final Integer LOOKAHEAD = 64;
     private final Deque<Character> pureTextFromFile = new LinkedList<>();
-
+    private final StringBuilder comment = new StringBuilder(20);
 
     public BibtexParser(Reader in) {
         Objects.requireNonNull(in);
@@ -206,7 +206,12 @@ public class BibtexParser {
     }
 
     private void parseRemainingContent() {
-        database.setEpilog(dumpTextReadSoFarToString().trim());
+        String commentStr = comment.toString();
+        if (commentStr.substring(0, 17).equals("% Encoding: UTF-8")) {
+            commentStr = commentStr.substring(18);
+        }
+        database.setEpilog(commentStr);
+        //database.setEpilog(dumpTextReadSoFarToString().trim());
     }
 
     private void parseAndAddEntry(String type) {
@@ -917,11 +922,16 @@ public class BibtexParser {
     }
 
     private boolean consumeUncritically(char expected) throws IOException {
+
         int character;
         do {
             character = read();
+            if (((char) character != expected) && (character != -1) && (character != 65535)) {
+                if ((char) character != '\n' || peek() != '\n') {
+                    comment.append((char) character);
+                }
+            }
         } while ((character != expected) && (character != -1) && (character != 65535));
-
         if (isEOFCharacter(character)) {
             eof = true;
         }

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -207,8 +207,10 @@ public class BibtexParser {
 
     private void parseRemainingContent() {
         String commentStr = comment.toString();
-        if (commentStr.substring(0, 17).equals("% Encoding: UTF-8")) {
-            commentStr = commentStr.substring(18);
+        if (commentStr.length() >= 18) {
+            if (commentStr.substring(0, 17).equals("% Encoding: UTF-8")) {
+                commentStr = commentStr.substring(18);
+            }
         }
         database.setEpilog(commentStr);
         //database.setEpilog(dumpTextReadSoFarToString().trim());
@@ -927,7 +929,7 @@ public class BibtexParser {
         do {
             character = read();
             if (((char) character != expected) && (character != -1) && (character != 65535)) {
-                if ((char) character != '\n' || peek() != '\n') {
+                if (((char) character != '\n') || (peek() != '\n')) {
                     comment.append((char) character);
                 }
             }

--- a/src/test/java/net/sf/jabref/es2test/ParseBibCommentsTest.java
+++ b/src/test/java/net/sf/jabref/es2test/ParseBibCommentsTest.java
@@ -1,0 +1,68 @@
+package net.sf.jabref.es2test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.importer.ParserResult;
+import net.sf.jabref.importer.fileformat.BibtexImporter;
+import net.sf.jabref.importer.fileformat.BibtexParser;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ParseBibCommentsTest {
+
+    private BibtexImporter importer;
+
+    @Before
+    public void setUp() {
+        Globals.prefs = JabRefPreferences.getInstance();
+    }
+
+    @Test
+    public void fromStringRecognizesComment() {
+        ParserResult result = null;
+        try {
+            result = BibtexParser.parse(new StringReader("%comment@article{test,author={Ed von Test}}"));
+        } catch (IOException e) {
+        }
+
+        assertEquals(result.getDatabase().getEpilog(), "%comment");
+    }
+
+    @Test
+    public void fromStringNotRecognizesComment() {
+        ParserResult result = null;
+        try {
+            result = BibtexParser.parse(new StringReader("%comment@article{test,author={Ed von Test}}"));
+        } catch (IOException e) {
+        }
+
+        assertNotEquals(result.getDatabase().getEpilog(), "%comment@article");
+    }
+
+    @Test
+    public void fromStringRecognizesMultipleComments() {
+        ParserResult result = null;
+        try {
+            result = BibtexParser.parse(new StringReader("%comment\n%comment@article{test,author={Ed von Test}}"));
+        } catch (IOException e) {
+        }
+
+        assertEquals(result.getDatabase().getEpilog(), "%comment\n%comment");
+    }
+
+    @Test
+    public void fromStringEmptyComment() {
+        ParserResult result = null;
+        try {
+            result = BibtexParser.parse(new StringReader("@article{test,author={Ed von Test}}"));
+        } catch (IOException e) {
+        }
+
+        assertEquals(result.getDatabase().getEpilog(), "");
+    }
+}
+


### PR DESCRIPTION
Foi implementada uma melhoria na modificação de bases de itens bibliográficos. Antes, todos os comentários eram apagados quando um arquivo .bib era modificado, exceto pelos que se localizavam ao fim do arquivo. Agora, com a manutenção feita, todos os comentários são conservados, porém deslocados para o fim do arquivo. Resolve #10 .

Também foram implementados testes para esta manutenção.
